### PR TITLE
Add configurable equipment to summoned mobs, zero all drop chances

### DIFF
--- a/src/main/java/com/cyberday1/neoorigins/power/builtin/SummonMinionPower.java
+++ b/src/main/java/com/cyberday1/neoorigins/power/builtin/SummonMinionPower.java
@@ -21,9 +21,14 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.phys.Vec3;
 
+import java.util.Optional;
+
 /**
  * Active power that summons a mob near the player. Summoned mobs are tracked
  * by MinionTracker with caps, despawn timers, and death-damage feedback.
+ *
+ * <p>Equipment can be configured per slot via JSON. All equipment drop chances
+ * are set to 0 — summoned mobs never drop loot.
  */
 public class SummonMinionPower extends AbstractActivePower<SummonMinionPower.Config> {
 
@@ -34,6 +39,12 @@ public class SummonMinionPower extends AbstractActivePower<SummonMinionPower.Con
         int hungerCost,
         int despawnTicks,
         float deathDamage,
+        Optional<String> head,
+        Optional<String> chest,
+        Optional<String> legs,
+        Optional<String> feet,
+        Optional<String> mainhand,
+        Optional<String> offhand,
         String type
     ) implements AbstractActivePower.Config {
         public static final Codec<Config> CODEC = RecordCodecBuilder.create(inst -> inst.group(
@@ -43,6 +54,12 @@ public class SummonMinionPower extends AbstractActivePower<SummonMinionPower.Con
             Codec.INT.optionalFieldOf("hunger_cost", 4).forGetter(Config::hungerCost),
             Codec.INT.optionalFieldOf("despawn_ticks", 18000).forGetter(Config::despawnTicks),
             Codec.FLOAT.optionalFieldOf("death_damage", 1.0f).forGetter(Config::deathDamage),
+            Codec.STRING.optionalFieldOf("head").forGetter(Config::head),
+            Codec.STRING.optionalFieldOf("chest").forGetter(Config::chest),
+            Codec.STRING.optionalFieldOf("legs").forGetter(Config::legs),
+            Codec.STRING.optionalFieldOf("feet").forGetter(Config::feet),
+            Codec.STRING.optionalFieldOf("mainhand").forGetter(Config::mainhand),
+            Codec.STRING.optionalFieldOf("offhand").forGetter(Config::offhand),
             Codec.STRING.optionalFieldOf("type", "").forGetter(Config::type)
         ).apply(inst, Config::new));
     }
@@ -81,10 +98,17 @@ public class SummonMinionPower extends AbstractActivePower<SummonMinionPower.Con
         if (living instanceof Mob mob) {
             mob.setPersistenceRequired();
 
-            // Equip undead mobs with a helmet so they don't burn in sunlight
-            if (mob.getItemBySlot(EquipmentSlot.HEAD).isEmpty()) {
-                mob.setItemSlot(EquipmentSlot.HEAD, new ItemStack(Items.IRON_HELMET));
-                mob.setDropChance(EquipmentSlot.HEAD, 0.0f);
+            // Apply configured equipment (or default helmet for sun protection)
+            equipSlot(mob, EquipmentSlot.HEAD, config.head(), Items.IRON_HELMET.getDefaultInstance());
+            equipSlot(mob, EquipmentSlot.CHEST, config.chest(), null);
+            equipSlot(mob, EquipmentSlot.LEGS, config.legs(), null);
+            equipSlot(mob, EquipmentSlot.FEET, config.feet(), null);
+            equipSlot(mob, EquipmentSlot.MAINHAND, config.mainhand(), null);
+            equipSlot(mob, EquipmentSlot.OFFHAND, config.offhand(), null);
+
+            // Zero all drop chances — summoned mobs never drop loot
+            for (EquipmentSlot slot : EquipmentSlot.values()) {
+                mob.setDropChance(slot, 0.0f);
             }
         }
 
@@ -110,9 +134,19 @@ public class SummonMinionPower extends AbstractActivePower<SummonMinionPower.Con
         return true;
     }
 
+    private static void equipSlot(Mob mob, EquipmentSlot slot, Optional<String> configItem, ItemStack fallback) {
+        if (configItem.isPresent()) {
+            var itemOpt = BuiltInRegistries.ITEM.get(Identifier.parse(configItem.get()));
+            if (itemOpt.isPresent()) {
+                mob.setItemSlot(slot, new ItemStack(itemOpt.get().value()));
+            }
+        } else if (fallback != null && mob.getItemBySlot(slot).isEmpty()) {
+            mob.setItemSlot(slot, fallback.copy());
+        }
+    }
+
     @Override
     public void onRevoked(ServerPlayer player, Config config) {
-        // Clean up minions when the power is revoked
         MinionTracker.clearAll(player.getUUID());
     }
 }

--- a/src/main/resources/data/neoorigins/origins/powers/necromancer_summon_skeleton.json
+++ b/src/main/resources/data/neoorigins/origins/powers/necromancer_summon_skeleton.json
@@ -5,5 +5,8 @@
   "cooldown_ticks": 400,
   "hunger_cost": 4,
   "despawn_ticks": 18000,
-  "death_damage": 1.0
+  "death_damage": 1.0,
+  "head": "minecraft:iron_helmet",
+  "chest": "minecraft:chainmail_chestplate",
+  "mainhand": "minecraft:bow"
 }

--- a/src/main/resources/data/neoorigins/origins/powers/necromancer_summon_wither.json
+++ b/src/main/resources/data/neoorigins/origins/powers/necromancer_summon_wither.json
@@ -5,5 +5,8 @@
   "cooldown_ticks": 600,
   "hunger_cost": 6,
   "despawn_ticks": 18000,
-  "death_damage": 1.0
+  "death_damage": 1.0,
+  "head": "minecraft:netherite_helmet",
+  "chest": "minecraft:netherite_chestplate",
+  "mainhand": "minecraft:stone_sword"
 }


### PR DESCRIPTION
## Summary
- Summon power JSON now supports per-slot equipment: `head`, `chest`, `legs`, `feet`, `mainhand`, `offhand`
- All equipment drop chances set to 0% — summoned mobs never drop loot
- Updated necromancer summons with proper loadouts

## JSON format
```json
{
  "type": "neoorigins:summon_minion",
  "mob_type": "minecraft:skeleton",
  "max_count": 3,
  "cooldown_ticks": 400,
  "hunger_cost": 4,
  "despawn_ticks": 18000,
  "death_damage": 1.0,
  "head": "minecraft:iron_helmet",
  "chest": "minecraft:chainmail_chestplate",
  "mainhand": "minecraft:bow"
}
```

## Necromancer loadouts
- **Wither Skeleton**: Netherite helmet + chestplate, stone sword
- **Skeleton Archer**: Iron helmet, chainmail chestplate, bow